### PR TITLE
Group posts and site pages

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,6 +18,15 @@
   <div class="container">
     <a class="path" href="{{ .Site.BaseURL }}">[{{ .Site.Title }}]</a>
     <span class="caret"># _</span>
+    {{ with (where $.Data.Pages "Section" "pages") }}
+      <div style="float: right;">
+      	{{ range $i, $page := . }}
+      	  {{ $isFirst := eq $i 0 }}
+	  {{ if not $isFirst }}|{{ end }}
+	  <a class="path" href="{{ .RelPermalink }}">{{ $page.Title }}</a>
+        {{ end }}
+      </div>
+    {{ end }}
   </div>
 </header>
 

--- a/layouts/partials/homepage.html
+++ b/layouts/partials/homepage.html
@@ -6,7 +6,7 @@
   <h1 class="headline">Recent Posts</h1>
 
   <div class="article-list">
-    {{ range first 3 .Data.Pages }}
+    {{ range first 3 (where .Data.Pages "Section" "post") }}
       {{ partial "article-list-item.html" . }}
     {{ end }}
   </div>


### PR DESCRIPTION
This PR does two simple things:

1) Only content pages under `content/posts` will be shown on the front page under "recent posts."
2) Add links on the right side of the header based on content pages under `content/pages`.

My reason for creating this is that I created an `about.md` page under `content`, and it showed up under "recent posts", so this is my solution to separate the two concepts.

One oddity is that, even though pages are shown as part of the common header, they don't show up if you're viewing a blog post because `.Data.Pages` seems to be empty unless you're on the homepage. Ideally, the pages would be available globally, but having them hidden on post pages isn't a blocker for me, and the root cause seems to be something in Hugo's internals that I haven't been able to track down yet.
