### PR TITLE
use path of baseURL when loading resources

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,9 +7,9 @@
 <meta name="author" content="{{ .Site.Params.author }}">
 {{ .Hugo.Generator }}
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="{{ "/css/style.css" | absURL }}" type="text/css">
+<link rel="stylesheet" href="{{ "css/style.css" | absURL }}" type="text/css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700" type="text/css">
-<link rel="alternate" href="{{ "/index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
+<link rel="alternate" href="{{ "index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
 <title>{{ $isHomePage := eq .Title .Site.Title }}{{ .Title }}{{ if eq $isHomePage false }} - {{ .Site.Title }}{{ end }}</title>
 </head>
 <body>


### PR DESCRIPTION
the baseURL can contain a path. in such a case a leading slash will remove that and try to load the resources from the top level.