### PR TITLE
"Urlize" Tags and Categories in Article and swap ".Hugo" for "hugo"

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -9,7 +9,7 @@
     <span class="key">{{ if $page.Date.IsZero }}published {{ end }}in</span>
     <span class="val">
 {{ range . }}
-        <a href="{{ . | printf "categories/%s" | relURL }}">{{ . }}</a>
+        <a href="{{ . | urlize | printf "categories/%s" | relURL }}">{{ . }}</a>
 {{ end }}
     </span>
 {{ end }}
@@ -18,7 +18,7 @@
     <span class="key">tags:</span>
     <span class="val">
 {{ range . }}
-        <a href="{{ . | printf "tags/%s" | relURL }}">{{ . }}</a>
+        <a href="{{ . | urlize | printf "tags/%s" | relURL }}">{{ . }}</a>
 {{ end }}
     </span>
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
 {{- with $.Param "author" }}
 <meta name="author" content="{{ . }}">
 {{- end }}
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}" type="text/css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700" type="text/css">

--- a/layouts/partials/homepage.html
+++ b/layouts/partials/homepage.html
@@ -21,7 +21,7 @@
   <section class="categories">
     {{ range $name, $value := . }}
     <h2 class="category">
-      <a href="{{ $baseurl }}categories/{{ $name | urlize }}">{{ title $name }}</a>
+      <a href="{{ $baseurl }}categories/{{ $name | urlize }}">{{ humanize $name | title }}</a>
       <small>({{ .Count }})</small>
     </h2>
     {{ end }}


### PR DESCRIPTION
Fixes:
* Tags and category text needs to be URL sanitized to not create broken links in Articles
* `.Hugo` is deprecated according to message, which suggests updating to use `hugo` instead:
```
WARN 2019/06/08 19:27:21 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function. 
```
* Humanize category link text to allow spaces

